### PR TITLE
Skip callback method for calculator #update action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v4.17.1 (August 2025)
+v4.17.1 (September 2025)
   - Bug fixes: Fix issue calculator edit for authors
 
 v4.17.0 (July 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.17.1 (August 2025)
+  - Bug fixes: Fix issue calculator edit for authors
+
 v4.17.0 (July 2025)
   - No changes
 

--- a/app/controllers/dradis/plugins/calculators/mitre/issues_controller.rb
+++ b/app/controllers/dradis/plugins/calculators/mitre/issues_controller.rb
@@ -1,7 +1,8 @@
 module Dradis::Plugins::Calculators::MITRE
   class IssuesController < ::IssuesController
-
     before_action only: :edit
+
+    skip_before_action :remove_unused_state_param
 
     def edit
       @issue_fields = Dradis::Plugins::Calculators::MITRE::V1::FIELDS.map do |field|


### PR DESCRIPTION
### Spec

In the main app's IssuesController, we sanitize the incoming params specifically around the state. Since the calculator's inherit from the main app IssuesController, the sanitize method is also called through the callback even though we don't need it.

### Check List

- [x] Added a CHANGELOG entry
