### PR TITLE
Remove unused check in tools_menu

### DIFF
--- a/app/views/dradis/plugins/calculators/mitre/_tools_menu.html.erb
+++ b/app/views/dradis/plugins/calculators/mitre/_tools_menu.html.erb
@@ -1,4 +1,4 @@
-<% unless defined?(Dradis::Pro) && current_user.role?(:contributor) %>
+<% unless defined?(Dradis::Pro) %>
   <li>
     <%= link_to 'Risk Calculators - MITRE ATT&CK', mitre_calculator.calculators_mitre_path, class: 'dropdown-item', data: { turbolinks: false } %>
   </li>


### PR DESCRIPTION
### Summary

The tools_menu for contributors now uses the `results_portal` feature so we don't need to check for the role in the calculator's tools_menu

### Check List

- [ ] Added a CHANGELOG entry
- [ ] Added specs
